### PR TITLE
[chg] 调整C++版本检测方法

### DIFF
--- a/src/GraphCtrl/GraphElement/GAdapter/GSingleton/GSingleton.h
+++ b/src/GraphCtrl/GraphElement/GAdapter/GSingleton/GSingleton.h
@@ -11,7 +11,7 @@
 
 #include "../GAdapter.h"
 
-#if _LIBCPP_STD_VER >= 17
+#if __cplusplus >= 201703L
 
 CGRAPH_NAMESPACE_BEGIN
 
@@ -53,5 +53,5 @@ CGRAPH_NAMESPACE_END
 
 #endif //CGRAPH_GSINGLETON_H
 
-#endif // _LIBCPP_STD_VER >= 17
+#endif // __cplusplus >= 201703L
 

--- a/src/GraphCtrl/GraphElement/GAdapter/GSingleton/GSingleton.inl
+++ b/src/GraphCtrl/GraphElement/GAdapter/GSingleton/GSingleton.inl
@@ -8,7 +8,7 @@
 
 #include "GSingleton.h"
 
-#if _LIBCPP_STD_VER >= 17
+#if __cplusplus >= 201703L
 
 CGRAPH_NAMESPACE_BEGIN
 
@@ -98,4 +98,4 @@ CStatus GSingleton<T>::setElementInfo(const std::set<GElementPtr> &dependElement
 
 CGRAPH_NAMESPACE_END
 
-#endif  //_LIBCPP_STD_VER >= 17
+#endif  //__cplusplus >= 201703L

--- a/src/GraphCtrl/GraphParam/GParam.h
+++ b/src/GraphCtrl/GraphParam/GParam.h
@@ -11,7 +11,7 @@
 
 #include <string>
 
-    #if _LIBCPP_STD_VER >= 17
+    #if __cplusplus >= 201703L
 #include <shared_mutex>
     #else
 #include <mutex>
@@ -24,7 +24,7 @@ CGRAPH_NAMESPACE_BEGIN
 
 class GParam : public GParamObject {
 public:
-#if _LIBCPP_STD_VER >= 17
+#if __cplusplus >= 201703L
     std::shared_mutex _param_shared_lock_;    // 用于参数互斥的锁信息
 #else
     std::mutex _param_shared_lock_;

--- a/src/UtilsCtrl/ThreadPool/UThreadPoolDefine.h
+++ b/src/UtilsCtrl/ThreadPool/UThreadPoolDefine.h
@@ -10,7 +10,7 @@
 #define CGRAPH_UTHREADPOOLDEFINE_H
 
 #include <thread>
-    #if _LIBCPP_STD_VER >= 17
+    #if __cplusplus >= 201703L
 #include <shared_mutex>
     #else
 # include <mutex>
@@ -21,7 +21,7 @@
 
 CGRAPH_NAMESPACE_BEGIN
 
-    #if _LIBCPP_STD_VER >= 17
+    #if __cplusplus >= 201703L
 using CGRAPH_READ_LOCK = std::shared_lock<std::shared_mutex>;
 using CGRAPH_WRITE_LOCK = std::unique_lock<std::shared_mutex>;
     #else

--- a/tutorial/T11-Singleton.cpp
+++ b/tutorial/T11-Singleton.cpp
@@ -11,7 +11,7 @@
 
 using namespace CGraph;
 
-#if _LIBCPP_STD_VER >= 17
+#if __cplusplus >= 201703L
 
 void tutorial_singleton() {
     GPipelinePtr pipeline = GPipelineFactory::create();


### PR DESCRIPTION
`_LIBCPP_STD_VER`宏在我的环境下因未被定义而不能正常工作（C++ 版本被认为低于 17），在 GCC 12 和 Clang 14 下都是如此。幸运的是，标准另外定义了`__cplusplus`可用于版本检测，它能在我的电脑上正常工作。

可参考 [cppreference/Predefined_macros](https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros)