### PR TITLE
[chg] lambda不再引用捕获循环变量

### DIFF
--- a/src/GraphCtrl/GraphElement/GElementManager.cpp
+++ b/src/GraphCtrl/GraphElement/GElementManager.cpp
@@ -65,8 +65,8 @@ CStatus GElementManager::run() {
 
         /** 将分解后的pipeline信息，以cluster为维度，放入线程池依次执行 */
         for (GClusterRef cluster : clusterArr) {
-            futures.emplace_back(thread_pool_->commit([&cluster] {
-                return cluster.process(false);
+            futures.emplace_back(thread_pool_->commit([clusterPtr=&cluster] {
+                return clusterPtr->process(false);
             }, this->schedule_strategy_));
 
             runElementSize += cluster.getElementNum();


### PR DESCRIPTION
[按引用捕获循环变量，但是在线程池中延迟执行](https://github.com/ChunelFeng/CGraph/blob/e853870c73f68a06b5ef38366f62daec58fefe43/src/GraphCtrl/GraphElement/GElementManager.cpp#L68)有时会引发悬挂引用，因为当线程池任务执行时，循环变量可能已经被销毁了。幸运的是，因为`cluster`是引用类型，所以这段代码大概不会出问题。

考虑通常做法，利用指针按值捕获的语义更加明确，可防止后来人遇见相同的问题。