### PR TITLE
[perf] optimize calcMaxCliqueSize loop

### DIFF
--- a/src/GraphCtrl/GraphElement/_GOptimizer/GMaxParaOptimizer.h
+++ b/src/GraphCtrl/GraphElement/_GOptimizer/GMaxParaOptimizer.h
@@ -116,11 +116,9 @@ protected:
         CSize eleSize = graph.size();
         CSize maxCliqueSize = 0;    // 最大团size
         std::vector<CSize> curClique;    // 当前团
-        std::vector<bool> visited(eleSize, false);    // 标记第n个，是否被用到过
 
-        std::function<void(CSize)> backtrack = [&](CSize depth) {
-            for (CSize i = 0; i < eleSize; i++) {
-                if (visited[i]) { continue; }    // 如果已经访问过了，则继续
+        std::function<void(CSize, CSize)> backtrack = [&](CSize start, CSize depth) {
+            for (CSize i = start; i < eleSize; i++) {
                 if (depth + eleSize - i <= maxCliqueSize) { return; }    // 剪枝策略：剩余的元素数量，已经不足以超过 max 值了
 
                 if (std::all_of(curClique.begin(), curClique.end(), [&](const int j) {
@@ -128,9 +126,7 @@ protected:
                     return 1 == graph[j][i];
                 })) {
                     curClique.push_back(i);
-                    visited[i] = true;
-                    backtrack(depth + 1);    // depth 表示，团里已有元素的个数
-                    visited[i] = false;
+                    backtrack(i + 1, depth + 1);    // depth 表示，团里已有元素的个数
                     curClique.pop_back();
                 }
             }
@@ -138,7 +134,7 @@ protected:
             maxCliqueSize = std::max(curClique.size(), maxCliqueSize);
         };
 
-        backtrack(0);    // 从第0层开始遍历
+        backtrack(0, 0);    // 从第0层开始遍历
         return maxCliqueSize;
     }
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -38,7 +38,7 @@ tutorial_list = {
         "TU01-ThreadPool",
         "TU02-Lru",
         "TU03-Trie",
-        "TU04-Timer"
+        "TU04-Timer",
         "TU05-Distance"
 }
 


### PR DESCRIPTION
尝试优化计算最大团的过程；

思路如下：
一个团中的每个顶点和其余的所有顶点都相连，顶点的遍历顺序不会影响团的计算结果，类似于排列和组合的关系；
改动是在搜索遍历时每当找到一个团中的顶点，直接从下一个顶点开始遍历，而不是每次都从头开始，也不需要额外标记；

按照原先的方案，假设存在某个团的顶点编号为 {3，2，1}，那么也应该存在 {1，2，3}，相当于同一个团按照不同的排列被多次找出，增加遍历的次数；
改动后应该只会按照编号递增的顺序找到团；