### PR TITLE
fix xmake.lua

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -44,5 +44,7 @@ tutorial_list = {
 for _, v in pairs(tutorial_list) do
     target(v)
         set_kind("binary")
+        add_includedirs("src")
+        add_headerfiles("src/CGraph.h")
         add_files("src/**.cpp", string.format("tutorial/%s.cpp", v))
 end


### PR DESCRIPTION
xmake.lua 文件修改，增加包含目录，与包含文件。在mac 下测试通过。