### PR TITLE
[fix] replacing include_directories with target_include_directories

### DIFF
--- a/cmake/CGraph-env-include.cmake
+++ b/cmake/CGraph-env-include.cmake
@@ -30,9 +30,9 @@ ELSEIF(WIN32)
     # 本工程也支持在windows平台上的mingw环境使用
 ENDIF()
 
-include_directories(${CGRAPH_PROJECT_ROOT_DIR}/src/)    # 直接加入"CGraph.h"文件对应的位置
-
 # 以下三选一，本地编译执行，推荐OBJECT方式
 add_library(CGraph OBJECT ${CGRAPH_PROJECT_SRC_LIST})      # 通过代码编译
 # add_library(CGraph SHARED ${CGRAPH_PROJECT_SRC_LIST})    # 编译libCGraph动态库
 # add_library(CGraph STATIC ${CGRAPH_PROJECT_SRC_LIST})    # 编译libCGraph静态库
+
+target_include_directories(CGraph PUBLIC ${CGRAPH_PROJECT_ROOT_DIR}/src/)    # 直接加入"CGraph.h"文件对应的位置

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CGRAPH_EXAMPLE_LIST
 
 foreach(example ${CGRAPH_EXAMPLE_LIST})
     add_executable(${example}
-            $<TARGET_OBJECTS:CGraph>
             ${example}.cpp
             )
+    target_link_libraries(${example} PRIVATE CGraph)
 endforeach()

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -34,7 +34,8 @@ set(CGRAPH_TUTORIAL_LIST
 foreach(tut ${CGRAPH_TUTORIAL_LIST})
     add_executable(${tut}
             # 在自己的工程中引入CGraph功能，仅需引入 CGraph-env-include.cmake 后，加入这一句话即可
-            $<TARGET_OBJECTS:CGraph>
             ${tut}.cpp
             )
+    target_link_libraries(${tut} PRIVATE CGraph)
+
 endforeach()


### PR DESCRIPTION
Fixes a cmake issue.
`include_directories` pollutes all includes and doesn't properly gets forwarded when used in external projects.

This should fix the issue.