### PR TITLE
Enable automatic code hinting for PyCGraph by improving stub file generation in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@
 /python/dist
 /python/PyCGraph.egg-info
 /python/src
+/python/*.pyi
 __pycache__

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,6 @@ dynamic = ["version", "description", "authors", "license", "readme", "requires-p
 
 dependencies = [
     "pybind11",
-    "pybind11-stubgen"
 ]
 
 [tool.setuptools]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11"]
+requires = ["setuptools", "wheel", "pybind11", "pybind11-stubgen"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,6 +8,7 @@ dynamic = ["version", "description", "authors", "license", "readme", "requires-p
 
 dependencies = [
     "pybind11",
+    "pybind11-stubgen"
 ]
 
 [tool.setuptools]

--- a/python/setup.py
+++ b/python/setup.py
@@ -9,6 +9,10 @@
 import glob
 from setuptools import setup, Extension
 import pybind11
+import os
+import sys
+import subprocess
+from setuptools.command.build_ext import build_ext as _build_ext
 
 __PYCGRAPH_NAME__ = "PyCGraph"
 __PYCGRAPH_VERSION__ = "3.1.2"
@@ -42,6 +46,26 @@ _ext_modules = [
     ),
 ]
 
+class build_ext(_build_ext):
+    def run(self):
+        super().run()
+        # 自动生成 stub 文件
+        try:
+            import pybind11_stubgen
+        except ImportError:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "pybind11-stubgen"])
+        # 生成 stub 文件到当前目录
+        subprocess.check_call([
+            sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__, "--output-dir=."
+        ])
+        # 拷贝生成的 .pyi 文件到包目录
+        build_lib = self.build_lib
+        stub_path = os.path.join(os.path.dirname(__file__), f"{__PYCGRAPH_NAME__}.pyi")
+        dst_pyi = os.path.join(os.path.dirname(__file__), build_lib, "PyCGraph.pyi")
+        if os.path.exists(stub_path):
+            import shutil
+            shutil.copy(stub_path, dst_pyi)
+
 setup(
     name=__PYCGRAPH_NAME__,
     version=__PYCGRAPH_VERSION__,
@@ -52,6 +76,9 @@ setup(
     license=__PYCGRAPH_LICENSE__,
     ext_modules=_ext_modules,
     zip_safe=False,
+    include_package_data=True,
+    package_data={"": ["*.pyi"]},  # 关键：包含所有 .pyi 文件
+    cmdclass={"build_ext": build_ext},
     long_description=__PYCGRAPH_LONG_DESCRIPTION__,
     long_description_content_type="text/markdown",
     python_requires=">=3.8",

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,11 +49,6 @@ _ext_modules = [
 class build_ext(_build_ext):
     def run(self):
         super().run()
-        # 自动生成 stub 文件
-        try:
-            import pybind11_stubgen
-        except ImportError:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "pybind11-stubgen"])
         # 生成 stub 文件到当前目录
         subprocess.check_call([
             sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__, "--output-dir=."

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,12 +49,14 @@ _ext_modules = [
 class build_ext(_build_ext):
     def run(self):
         super().run()
+        build_lib = self.build_lib
+        sys.path.insert(0, build_lib)
         # 生成 stub 文件到当前目录
         subprocess.check_call([
-            sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__, "--output-dir=."
+            sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__,
+            "--output-dir=.", f"--search-path={build_lib}"
         ])
         # 拷贝生成的 .pyi 文件到包目录
-        build_lib = self.build_lib
         stub_path = os.path.join(os.path.dirname(__file__), f"{__PYCGRAPH_NAME__}.pyi")
         dst_pyi = os.path.join(os.path.dirname(__file__), build_lib, "PyCGraph.pyi")
         if os.path.exists(stub_path):

--- a/python/setup.py
+++ b/python/setup.py
@@ -50,12 +50,11 @@ class build_ext(_build_ext):
     def run(self):
         super().run()
         build_lib = self.build_lib
-        sys.path.insert(0, build_lib)
-        # 生成 stub 文件到当前目录
+        env = os.environ.copy()
+        env["PYTHONPATH"] = build_lib + os.pathsep + env.get("PYTHONPATH", "")
         subprocess.check_call([
-            sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__,
-            "--output-dir=.", f"--search-path={build_lib}"
-        ])
+            sys.executable, "-m", "pybind11_stubgen", __PYCGRAPH_NAME__, "--output-dir=."
+        ], env=env)
         # 拷贝生成的 .pyi 文件到包目录
         stub_path = os.path.join(os.path.dirname(__file__), f"{__PYCGRAPH_NAME__}.pyi")
         dst_pyi = os.path.join(os.path.dirname(__file__), build_lib, "PyCGraph.pyi")


### PR DESCRIPTION
This PR updates the build_ext class in python/setup.py to enhance the developer experience when using PyCGraph:

- Ensures .pyi stub files are generated and placed correctly, enabling automatic code hinting and autocompletion in IDEs.

- Sets the PYTHONPATH environment variable to include the build_lib directory, so pybind11_stubgen can locate the built extension module.

- Simplifies the pybind11_stubgen invocation and removes unnecessary sys.path modifications.

With these changes, developers will benefit from improved code completion and type hints when working with PyCGraph in Python IDEs.