### PR TITLE
[bugfix] fix left_depend_ counter bug when element returns error in t…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,5 +34,6 @@ Contributors:
 - [SolerHo](https://github.com/SolerHo)
 - [guanquanchen](https://github.com/guanquanchen)
 - [Linyu](https://github.com/weijinglin)
+- [billlib](https://github.com/billlib)
 
 感谢以上朋友，为CGraph项目做出的贡献，排名以贡献时间前后为顺序。

--- a/src/GraphCtrl/GraphElement/_GEngine/GDynamicEngine/GDynamicEngine.cpp
+++ b/src/GraphCtrl/GraphElement/_GEngine/GDynamicEngine/GDynamicEngine.cpp
@@ -207,6 +207,15 @@ CVoid GDynamicEngine::fatWait() {
          */
         return (finished_end_size_ >= total_end_size_) || cur_status_.isErr();
     });
+    
+    // 状态异常的情况下刷新所有element，避免错误的中间状态被带入下一次process
+    if (cur_status_.isErr())
+    {
+        for (auto &e : total_element_arr_)
+        {
+            e->refresh();
+        }
+    }
 }
 
 


### PR DESCRIPTION
commonRunAll：在pipeline执行中途有element return error的情况下，下游未执行的element的left_depend_计数器有可能被做了数次减1、但是并不会被重置。如果接着马上执行下一次process，那么left_depend_的问题就会导致不应该并行的element并行跑起来了。

在出错的情况下，保险起见，我们应该对这条pipeline的所有element做refresh，刷新它们的"中间状态"（为方便后续其他人理解，我们统称left_depend_这类计数器为element的"中间状态"）。