### PR TITLE
[bugfix] fix node exception notify miss

### DIFF
--- a/src/GraphCtrl/GraphElement/_GEngine/GDynamicEngine/GDynamicEngine.cpp
+++ b/src/GraphCtrl/GraphElement/_GEngine/GDynamicEngine/GDynamicEngine.cpp
@@ -143,8 +143,11 @@ CVoid GDynamicEngine::innerExec(GElementPtr element) {
         afterElementRun(element);
     } else {
         // 遇到异常情况，结束整体逻辑
-        CGRAPH_LOCK_GUARD lk(status_lock_);
-        cur_status_ += curStatus;
+        {
+            CGRAPH_LOCK_GUARD lk(status_lock_);
+            cur_status_ += curStatus;
+        }
+        CGRAPH_LOCK_GUARD lk(locker_.mtx_);
         locker_.cv_.notify_one();
     }
 }


### PR DESCRIPTION
老代码
```cpp
 else {
        // 遇到异常情况，结束整体逻辑
        CGRAPH_LOCK_GUARD lk(status_lock_);
        cur_status_ += curStatus;
        locker_.cv_.notify_one();
    }
```

新代码
```cpp
 else {
        // 遇到异常情况，结束整体逻辑
        {
            CGRAPH_LOCK_GUARD lk(status_lock_);
            cur_status_ += curStatus;
        }
        CGRAPH_LOCK_GUARD lk(locker_.mtx_);
        locker_.cv_.notify_one();
    }
```

fatWait() 代码如下
```cpp
CVoid GDynamicEngine::fatWait() {
    CGRAPH_UNIQUE_LOCK lock(locker_.mtx_);
    locker_.cv_.wait(lock, [this] {
        /**
         * 遇到以下条件之一，结束执行：
         * 1，执行结束
         * 2，状态异常
         */
        return (finished_end_size_ >= total_end_size_) || cur_status_.isErr();
    });
}
```

1. 主线程 fatWait() 持有locker_.mtx_ 锁，还没出错
2. Worker 线程执行 element 出错，获取status_lock_锁，设置 cur_status_为错误
3. Worker notify（不需要 locker_.mtx_，也是问题所在）
4. 但主线程此时没有进入wait 状态
5. 主线程进入 wait，释放锁，阻塞
6.  没有后续通知 -> 永久挂起
